### PR TITLE
Clean up search range changes (#138)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,9 +48,6 @@ dependencies {
     compile 'com.google.android.gms:play-services-maps:9.2.1'
     compile 'com.google.android.gms:play-services-location:9.2.1'
 
-    //Pokemon Go API - Got double pokemon bug
-    //compile 'com.github.Grover-c13:PokeGOAPI-Java:4f5b715380'
-
     //Pokemon Go API
     compile 'com.github.Grover-c13:PokeGOAPI-Java:2e14fab7f0'
 

--- a/app/src/main/java/com/omkarmoghe/pokemap/controllers/net/NianticManager.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/controllers/net/NianticManager.java
@@ -2,6 +2,7 @@ package com.omkarmoghe.pokemap.controllers.net;
 
 import android.os.HandlerThread;
 
+import com.google.android.gms.maps.model.LatLng;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.omkarmoghe.pokemap.models.events.CatchablePokemonEvent;
@@ -13,7 +14,6 @@ import android.util.Log;
 import com.omkarmoghe.pokemap.models.events.InternalExceptionEvent;
 import com.omkarmoghe.pokemap.models.events.LoginEventResult;
 import com.omkarmoghe.pokemap.models.events.ServerUnreachableEvent;
-import com.omkarmoghe.pokemap.models.map.LatLng;
 import com.omkarmoghe.pokemap.models.map.SearchParams;
 import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.api.map.pokemon.CatchablePokemon;
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 
 import POGOProtos.Networking.Envelopes.RequestEnvelopeOuterClass.RequestEnvelope.AuthInfo;
 
@@ -285,22 +286,18 @@ public class NianticManager {
                 try {
                     if (mPokemonGo != null) {
 
-                        SearchParams params = new SearchParams(SearchParams.DEFAULT_RADIUS * 3, new LatLng(lat, longitude));
-                        List<LatLng> list = params.getSearchArea();
-                        List<CatchablePokemon> pokemon = new ArrayList<>();
-                        for (LatLng p : list) {
-                            //This fixes Exception of missind ID
-                            Thread.sleep(50);
-                            mPokemonGo.setLocation(p.latitude, p.longitude, alt);
-                            pokemon.addAll(mPokemonGo.getMap().getCatchablePokemon());
-                        }
-
-                        EventBus.getDefault().post(new CatchablePokemonEvent(pokemon));
+                        //This fixes Exception of missind ID
+                        Thread.sleep(50);
+                        mPokemonGo.setLocation(lat, longitude, alt);
+                        EventBus.getDefault().post(new CatchablePokemonEvent(mPokemonGo.getMap().getCatchablePokemon()));
                     }
+
                 } catch (LoginFailedException e) {
                     EventBus.getDefault().post(new LoginEventResult(false, null, null));
                 } catch (RemoteServerException e) {
                     EventBus.getDefault().post(new ServerUnreachableEvent(e));
+                } catch (NullPointerException e) {
+                    e.printStackTrace();
                 } catch (Exception e) {
                     EventBus.getDefault().post(new InternalExceptionEvent(e));
                 }

--- a/app/src/main/java/com/omkarmoghe/pokemap/helpers/MapHelper.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/helpers/MapHelper.java
@@ -1,41 +1,29 @@
-package com.omkarmoghe.pokemap.models.map;
+package com.omkarmoghe.pokemap.helpers;
 
-import android.os.Parcel;
-import android.os.Parcelable;
+import com.google.android.gms.maps.model.LatLng;
 
 /**
- * Created by chris on 7/24/2016.
+ * Created by localuser on 7/25/2016.
  */
-
-public class LatLng implements Parcelable {
-
-    private static final String TAG = "LatLng";
+public class MapHelper {
 
     //Radius of the Earth in km
     public static final double EARTH = 6371;
-
-    public final double latitude;
-    public final double longitude;
-
-    public LatLng(double latitude, double longitude) {
-        this.latitude = latitude;
-        this.longitude = longitude;
-    }
 
     /**
      * Returns the distance from 'this' point to destination point (using haversine formula).
      *
      * @return Distance between this point and destination point, in same units as radius.
      */
-    public double distance(LatLng point){
+    public static double distance(LatLng pointA, LatLng pointB){
         //Getting the coordinates and converting them to radians
-        double lat = Math.toRadians(latitude);
-        double lat2 = Math.toRadians(point.latitude);
+        double lat = Math.toRadians(pointA.latitude);
+        double lat2 = Math.toRadians(pointB.latitude);
 
         //Getting the differences between the Lat and Long coordinates and
         //converting them to radians
-        double difLat = Math.toRadians(point.latitude-latitude);
-        double difLong = Math.toRadians(point.longitude - longitude);
+        double difLat = Math.toRadians(pointB.latitude - pointA.latitude);
+        double difLong = Math.toRadians(pointB.longitude - pointA.longitude);
 
         //Calculating the Haversine formula - a
         double a = (Math.pow(Math.sin(difLat/2), 2)) +
@@ -51,17 +39,18 @@ public class LatLng implements Parcelable {
     /**
      * Returns the destination point from the starting point point having travelled the given distance on the
      * given initial bearing (bearing normally varies around path followed).
+     * @param point - original location in the map to translate
      * @param distance - the distance between the current point and the new point
      * @param bearing - the bearing of the object moving (clockwise from north) in degrees (0-360)
      * @return An ArcGIS Point class storing the the Latitude and Longitude in decimal degrees.
      *  The x coordinate is the Longitude, the y coordinate is the Latitude
      */
-    public LatLng translatePoint(double distance, double bearing){
+    public static LatLng translatePoint(LatLng point, double distance, double bearing){
         distance = distance/1000d;
 
         //converts the Latitude, Longitude and bearings into radians
-        double lat = Math.toRadians(latitude);
-        double lng = Math.toRadians(longitude);
+        double lat = Math.toRadians(point.latitude);
+        double lng = Math.toRadians(point.longitude);
         bearing = Math.toRadians(bearing);
 
         //Give the distance and the first Latitude, computes the second latitude
@@ -79,41 +68,4 @@ public class LatLng implements Parcelable {
         //Creates a point object to return back. X is the longitude, Y is the Latitude
         return new LatLng(Lat2, Long2);
     }
-
-    public com.google.android.gms.maps.model.LatLng toLatLng(){
-        return new com.google.android.gms.maps.model.LatLng(latitude, longitude);
-    }
-
-    @Override
-    public String toString() {
-        return "Lat/Long: (" + latitude + ", " + longitude + ')';
-    }
-
-    @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-        dest.writeDouble(this.latitude);
-        dest.writeDouble(this.longitude);
-    }
-
-    protected LatLng(Parcel in) {
-        this.latitude = in.readDouble();
-        this.longitude = in.readDouble();
-    }
-
-    public static final Parcelable.Creator<LatLng> CREATOR = new Parcelable.Creator<LatLng>() {
-        @Override
-        public LatLng createFromParcel(Parcel source) {
-            return new LatLng(source);
-        }
-
-        @Override
-        public LatLng[] newArray(int size) {
-            return new LatLng[size];
-        }
-    };
 }

--- a/app/src/main/java/com/omkarmoghe/pokemap/models/map/SearchParams.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/models/map/SearchParams.java
@@ -2,6 +2,9 @@ package com.omkarmoghe.pokemap.models.map;
 
 import android.util.Log;
 
+import com.google.android.gms.maps.model.LatLng;
+import com.omkarmoghe.pokemap.helpers.MapHelper;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,43 +35,43 @@ public class SearchParams {
         for (int i = 2; i <= steps; i++) {
 
             LatLng prev = searchArea.get(searchArea.size() - (1 + count));
-            LatLng next = prev.translatePoint(DISTANCE, 0.0);
+            LatLng next = MapHelper.translatePoint(prev, DISTANCE, 0.0);
             searchArea.add(next);
 
             for (int j = 0; j < i - 1; j ++) {
                 prev = searchArea.get(searchArea.size() - 1);
-                next = prev.translatePoint(DISTANCE, 120.0);
+                next = MapHelper.translatePoint(prev, DISTANCE, 120.0);
                 searchArea.add(next);
             }
 
             // go due south
             for (int j = 0; j < i - 1; j ++) {
                 prev = searchArea.get(searchArea.size() - 1);
-                next = prev.translatePoint(DISTANCE, 180.0);
+                next = MapHelper.translatePoint(prev, DISTANCE, 180.0);
                 searchArea.add(next);
             }
             // go south-west
             for (int j = 0; j < i - 1 ; j ++) {
                 prev = searchArea.get(searchArea.size() - 1);
-                next = prev.translatePoint(DISTANCE, 240.0);
+                next = MapHelper.translatePoint(prev, DISTANCE, 240.0);
                 searchArea.add(next);
             }
             // go north-west
             for (int j = 0; j < i - 1; j ++) {
                 prev = searchArea.get(searchArea.size() - 1);
-                next = prev.translatePoint(DISTANCE, 300.0);
+                next = MapHelper.translatePoint(prev, DISTANCE, 300.0);
                 searchArea.add(next);
             }
             // go due north
             for (int j = 0; j < i - 1; j ++) {
                 prev = searchArea.get(searchArea.size() - 1);
-                next = prev.translatePoint(DISTANCE, 0.0);
+                next = MapHelper.translatePoint(prev, DISTANCE, 0.0);
                 searchArea.add(next);
             }
             // go north-east
             for (int j = 0; j < i - 2; j ++) {
                 prev = searchArea.get(searchArea.size() - 1);
-                next = prev.translatePoint(DISTANCE, 60.0);
+                next = MapHelper.translatePoint(prev, DISTANCE, 60.0);
                 searchArea.add(next);
             }
 

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/MainActivity.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/MainActivity.java
@@ -16,6 +16,7 @@ import com.omkarmoghe.pokemap.models.events.InternalExceptionEvent;
 import com.omkarmoghe.pokemap.models.events.LoginEventResult;
 import com.omkarmoghe.pokemap.models.events.SearchInPosition;
 import com.omkarmoghe.pokemap.models.events.ServerUnreachableEvent;
+import com.omkarmoghe.pokemap.models.map.SearchParams;
 import com.omkarmoghe.pokemap.controllers.map.LocationManager;
 import com.omkarmoghe.pokemap.views.map.MapWrapperFragment;
 import com.omkarmoghe.pokemap.views.settings.SettingsActivity;
@@ -24,6 +25,8 @@ import com.omkarmoghe.pokemap.controllers.app_preferences.PokemapSharedPreferenc
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
+
+import java.util.List;
 
 public class MainActivity extends BaseActivity {
     private static final String TAG = "Pokemap";
@@ -125,7 +128,13 @@ public class MainActivity extends BaseActivity {
      */
     @Subscribe
     public void onEvent(SearchInPosition event) {
-        nianticManager.getCatchablePokemon(event.getPosition().latitude, event.getPosition().longitude, 0D);
+        SearchParams params = new SearchParams(SearchParams.DEFAULT_RADIUS * 3, new LatLng(event.getPosition().latitude, event.getPosition().longitude));
+        List<LatLng> list = params.getSearchArea();
+        for (LatLng p : list) {
+            nianticManager.getCatchablePokemon(p.latitude, p.longitude, 0D);
+        }
+
+
     }
 
     /**

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
@@ -39,6 +39,7 @@ import com.omkarmoghe.pokemap.controllers.map.LocationManager;
 import com.omkarmoghe.pokemap.models.map.PokemonMarkerExtended;
 import com.omkarmoghe.pokemap.models.events.CatchablePokemonEvent;
 import com.omkarmoghe.pokemap.models.events.SearchInPosition;
+import com.omkarmoghe.pokemap.models.map.SearchParams;
 import com.omkarmoghe.pokemap.views.MainActivity;
 import com.pokegoapi.api.map.pokemon.CatchablePokemon;
 
@@ -46,6 +47,7 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -72,7 +74,7 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
     private GoogleMap mGoogleMap;
     private Location mLocation = null;
     private Marker userSelectedPositionMarker = null;
-    private Circle userSelectedPositionCircle = null;
+    private ArrayList<Circle> userSelectedPositionCircles = new ArrayList<>();
     private HashMap<String, PokemonMarkerExtended> markerList = new HashMap<>();
 
     public MapWrapperFragment() {
@@ -188,18 +190,18 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
     }
 
     private void updatePokemonMarkers() {
-        if (mGoogleMap != null && markerList != null && !markerList.isEmpty()){
-            for(Iterator<Map.Entry<String, PokemonMarkerExtended>> it = markerList.entrySet().iterator(); it.hasNext(); ) {
+        if (mGoogleMap != null && markerList != null && !markerList.isEmpty()) {
+            for (Iterator<Map.Entry<String, PokemonMarkerExtended>> it = markerList.entrySet().iterator(); it.hasNext(); ) {
                 Map.Entry<String, PokemonMarkerExtended> entry = it.next();
                 CatchablePokemon catchablePokemon = entry.getValue().getCatchablePokemon();
                 Marker marker = entry.getValue().getMarker();
                 long millisLeft = catchablePokemon.getExpirationTimestampMs() - System.currentTimeMillis();
-                if(millisLeft < 0) {
+                if (millisLeft < 0) {
                     marker.remove();
                     it.remove();
                 } else {
                     marker.setSnippet(getExpirationBreakdown(millisLeft));
-                    if(marker.isInfoWindowShown()) {
+                    if (marker.isInfoWindowShown()) {
                         marker.showInfoWindow();
                     }
                 }
@@ -232,7 +234,6 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
                                             .title(poke.getPokemonId().name())
                                             .icon(BitmapDescriptorFactory.fromBitmap(bitmap))
                                             .anchor(0.5f, 0.5f));
-
                                     //adding pokemons to list to be removed on next search
                                     markerList.put(poke.getSpawnPointId(), new PokemonMarkerExtended(poke, marker));
                                 }
@@ -241,7 +242,6 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
                     pokemonFound++;
                 }
             }
-
             if(getView() != null) {
                 String text = pokemonFound > 0 ? pokemonFound + " new catchable Pokemon have been found." : "No new Pokemon have been found.";
                 Snackbar.make(getView(), text, Snackbar.LENGTH_SHORT).show();
@@ -296,9 +296,6 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
      */
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEvent(CatchablePokemonEvent event) {
-        if(getView() != null) {
-            Snackbar.make(getView(), "Found " + event.getCatchablePokemon().size() + " Pokemon", Snackbar.LENGTH_SHORT).show();
-        }
         setPokemonMarkers(event.getCatchablePokemon());
     }
 
@@ -335,31 +332,38 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
     }
 
     private void drawMarkerWithCircle(LatLng position){
+            if (mGoogleMap != null) {
+                    //Check and eventually remove old marker
+                if (userSelectedPositionMarker != null && userSelectedPositionCircles != null) {
+                    userSelectedPositionMarker.remove();
+                    for (Circle circle : userSelectedPositionCircles) {
+                        circle.remove();
+                    }
+                    userSelectedPositionCircles.clear();
+                }
 
-        if (mGoogleMap != null) {
 
-            //Check and eventually remove old marker
-            if (userSelectedPositionMarker != null && userSelectedPositionCircle != null) {
-                userSelectedPositionMarker.remove();
-                userSelectedPositionCircle.remove();
+                double radiusInMeters = 100.0;
+                int strokeColor = 0x4400CCFF; // outline
+                int shadeColor = 0x4400CCFF; // fill
+
+                SearchParams params = new SearchParams(SearchParams.DEFAULT_RADIUS * 3, new LatLng(position.latitude, position.longitude));
+                List<LatLng> list = params.getSearchArea();
+                for (LatLng p : list) {
+                    CircleOptions circleOptions = new CircleOptions().center(new LatLng(p.latitude, p.longitude)).radius(radiusInMeters).fillColor(shadeColor).strokeColor(strokeColor).strokeWidth(8);
+                    userSelectedPositionCircles.add(mGoogleMap.addCircle(circleOptions));
+
+                }
+
+                userSelectedPositionMarker = mGoogleMap.addMarker(new MarkerOptions()
+                        .position(position)
+                        .title("Position Picked")
+                        .icon(BitmapDescriptorFactory.fromBitmap(BitmapFactory.decodeResource(getContext().getResources(),
+                                R.drawable.ic_my_location_white_24dp)))
+                        .anchor(0.5f, 0.5f));
+            } else {
+                showMapNotInitializedError();
             }
-
-            double radiusInMeters = 100.0;
-            int strokeColor = 0xff3399FF; // outline
-            int shadeColor = 0x4400CCFF; // fill
-
-            CircleOptions circleOptions = new CircleOptions().center(position).radius(radiusInMeters).fillColor(shadeColor).strokeColor(strokeColor).strokeWidth(8);
-            userSelectedPositionCircle = mGoogleMap.addCircle(circleOptions);
-
-            userSelectedPositionMarker = mGoogleMap.addMarker(new MarkerOptions()
-                    .position(position)
-                    .title("Position Picked")
-                    .icon(BitmapDescriptorFactory.fromBitmap(BitmapFactory.decodeResource(getContext().getResources(),
-                            R.drawable.ic_my_location_white_24dp)))
-                    .anchor(0.5f, 0.5f));
-        } else {
-            showMapNotInitializedError();
-        }
     }
 
 }


### PR DESCRIPTION
* - Check permissions to set my location
- Change scanning location marker to a smaller one
- Center pokemon markers
- Add pokemon markers to a hashmap to keep track of all the previous scans
- Update marker snipper with current expiration, added a update markers method
- Call the update markers on resume and after scanning

* Show how many new pokemon where found after the latest scan.

* - Moved PokemonMarkerExtended to map package.

* Removed hack for negative expiration. Assuming that a -1 expiration means that the pokemon is expired and will be removed in the new update.

* Change the calls to the to get the range search to MainActivity and let the events and threads do the job of getting multiple steps at a time.

* Remove conflicted name class LatLng and add MapHelper to have the distance and translatePoint methods static.

* Remove extra loop in Niamtic Manager

* Make hex weaker.

* Fix niantic manager to prevent double call to range search.